### PR TITLE
Don't pre-evaluate the inner predicates before operatorFunction

### DIFF
--- a/kevi/operators.py
+++ b/kevi/operators.py
@@ -65,6 +65,5 @@ class CompoundPredicateOperator(PredicateOperator):
 		# assert self._compoundPredicateType in (CompoundPredicateType.And, CompoundPredicateType.Or), 'compoundPredicateType is not Not, and is neither And or Or'
 
 		operatorFunction = self.operatorFunction()
-		evaluatedPredicates = [p.evaluateWithObject(obj) for p in predicates]
 
-		return operatorFunction(evaluatedPredicates)
+		return operatorFunction(p.evaluateWithObject(obj) for p in predicates)


### PR DESCRIPTION
Pass the results of evaluating the inner predicates as a generator to
operatorFunction, avoiding unnecessary evaluation of predicates if the
result of an operator can be determined without passing over every
single predicate.

Resolves #8.