### PR TITLE
Issue 10: Fix Not predicate operator

### DIFF
--- a/kevi/operators.py
+++ b/kevi/operators.py
@@ -65,5 +65,6 @@ class CompoundPredicateOperator(PredicateOperator):
 		# assert self._compoundPredicateType in (CompoundPredicateType.And, CompoundPredicateType.Or), 'compoundPredicateType is not Not, and is neither And or Or'
 
 		operatorFunction = self.operatorFunction()
+		evaluatedPredicates = (p.evaluateWithObject(obj) for p in predicates)
 
-		return operatorFunction(p.evaluateWithObject(obj) for p in predicates)
+		return operatorFunction(evaluatedPredicates)

--- a/kevi/operators.py
+++ b/kevi/operators.py
@@ -56,7 +56,7 @@ class ComparisonPredicateOperator(PredicateOperator):
 class CompoundPredicateOperator(PredicateOperator):
 
 	_operatorFunctionsByType = {
-		predicates.CompoundPredicateType.Not: lambda p: not p[0],
+		predicates.CompoundPredicateType.Not: lambda p: not next(p),
 		predicates.CompoundPredicateType.And: getattr(builtins, 'all'),
 		predicates.CompoundPredicateType.Or:  getattr(builtins, 'any')
 	}


### PR DESCRIPTION
fdbcd42 changed the return value of
CompoundPredicateOperator.evaluatePredicatesWithObject from a list to a
generator. This makes p[0] invalid. Change the lambda function for
CompoundPredicateType.Not to use next(p), instead.

Resolves #10.